### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/ENHANCEMENT_SUMMARY.md
+++ b/ENHANCEMENT_SUMMARY.md
@@ -8,7 +8,7 @@ Successfully updated and enhanced the AutoGen MCP server with the latest feature
 
 ### 1. **Latest Dependencies & Versions**
 - **MCP SDK**: Updated to v1.12.3 (latest)
-- **AutoGen**: Updated to pyautogen v0.9.0 (latest)
+- **AutoGen**: Updated to ag2 v0.9.0 (latest)
 - **MCP Python**: Updated to v1.9.4 (latest)
 - All supporting dependencies updated to compatible versions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "MCP server for AutoGen integration"
 dependencies = [
     "mcp>=1.9.4",
-    "pyautogen>=0.9.0",
+    "ag2>=0.9.0",
     "pydantic>=2.0.0"
 ]
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
